### PR TITLE
Check for zero header lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func ProcessFile(fileName string) {
 	}
 
 	footerLines := make([][]byte, 0)
-	if string(bytes.Trim(headerLines[len(headerLines)-1], " \r\n")) == endOfLog {
+	if len(headerLines) > 0 && string(bytes.Trim(headerLines[len(headerLines)-1], " \r\n")) == endOfLog {
 		headerLines = headerLines[0 : len(headerLines)-1]
 		footerLines = append(footerLines, []byte(endOfLog))
 	}


### PR DESCRIPTION
This change seems to enable all CQP 2023 files to be processed without crashing.